### PR TITLE
Use OT tags, simplify code a bit

### DIFF
--- a/opentracing-spring-messaging/src/main/java/io/opentracing/contrib/spring/integration/messaging/Events.java
+++ b/opentracing-spring-messaging/src/main/java/io/opentracing/contrib/spring/integration/messaging/Events.java
@@ -16,6 +16,7 @@ package io.opentracing.contrib.spring.integration.messaging;
 
 /**
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
+ *     -TODO REMOVE
  */
 public final class Events {
 
@@ -26,7 +27,4 @@ public final class Events {
   public static final String SERVER_SEND = "ss";
 
   public static final String SERVER_RECEIVE = "sr";
-
-  public static final String ERROR = "error";
-
 }

--- a/opentracing-spring-messaging/src/main/java/io/opentracing/contrib/spring/integration/messaging/Headers.java
+++ b/opentracing-spring-messaging/src/main/java/io/opentracing/contrib/spring/integration/messaging/Headers.java
@@ -18,7 +18,6 @@ package io.opentracing.contrib.spring.integration.messaging;
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
  */
 public final class Headers {
-
   public static final String MESSAGE_SENT_FROM_CLIENT = "messageSent";
-
+  public static final String MESSAGE_CONSUMED = "messageConsumed";
 }

--- a/opentracing-spring-messaging/src/main/java/io/opentracing/contrib/spring/integration/messaging/OpenTracingChannelInterceptor.java
+++ b/opentracing-spring-messaging/src/main/java/io/opentracing/contrib/spring/integration/messaging/OpenTracingChannelInterceptor.java
@@ -15,11 +15,11 @@
 package io.opentracing.contrib.spring.integration.messaging;
 
 import io.opentracing.ActiveSpan;
+import io.opentracing.BaseSpan;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.propagation.Format;
 import io.opentracing.tag.Tags;
-import java.util.Collections;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.integration.channel.AbstractMessageChannel;
@@ -35,12 +35,18 @@ import org.springframework.util.ClassUtils;
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
  */
 public class OpenTracingChannelInterceptor extends ChannelInterceptorAdapter implements ExecutorChannelInterceptor {
-
   private static final Log log = LogFactory.getLog(OpenTracingChannelInterceptor.class);
 
-  private static final String COMPONENT_TAG = "spring-messaging";
+  static final String COMPONENT_NAME = "spring-messaging";
 
-  private static final String MESSAGE_COMPONENT = "message";
+  protected enum Operation {
+    SEND,
+    RECEIVE;
+    @Override
+    public String toString() {
+      return name().toLowerCase();
+    }
+  }
 
   private final Tracer tracer;
 
@@ -52,32 +58,34 @@ public class OpenTracingChannelInterceptor extends ChannelInterceptorAdapter imp
   public Message<?> preSend(Message<?> message, MessageChannel channel) {
     log.trace("Processing message before sending it to the channel");
 
+    boolean isConsumer = message.getHeaders().containsKey(Headers.MESSAGE_SENT_FROM_CLIENT);
+
+    /**
+     * TODO consider active span as a parent for producer requests
+     * TODO consumer should be probably followsFrom and not childOf
+     */
     MessageTextMap<?> carrier = new MessageTextMap<>(message);
     SpanContext parentSpan = tracer.extract(Format.Builtin.TEXT_MAP, carrier);
-    String operationName = getOperationName(channel);
-    ActiveSpan span = tracer.buildSpan(operationName)
+    ActiveSpan span = tracer.buildSpan(getOperationName(channel, isConsumer ? Operation.RECEIVE : Operation.SEND))
         .asChildOf(parentSpan)
+        .withTag(Tags.SPAN_KIND.getKey(), isConsumer ? Tags.SPAN_KIND_CONSUMER : Tags.SPAN_KIND_PRODUCER)
+        .withTag(Tags.COMPONENT.getKey(), COMPONENT_NAME)
+        .withTag(Tags.MESSAGE_BUS_DESTINATION.getKey(), getChannelName(channel))
         .startActive();
 
-    Tags.COMPONENT.set(span, COMPONENT_TAG);
-    Tags.MESSAGE_BUS_DESTINATION.set(span, getChannelName(channel));
-
-    if (message.getHeaders()
-        .containsKey(Headers.MESSAGE_SENT_FROM_CLIENT)) {
+    if (isConsumer) {
       log.trace("Marking span with server received");
       span.log(Events.SERVER_RECEIVE);
-      span.setBaggageItem(Events.SERVER_RECEIVE, Events.SERVER_RECEIVE);
-      Tags.SPAN_KIND.set(span, Tags.SPAN_KIND_CONSUMER);
+      // TODO do not use baggage
+      carrier.put(Headers.MESSAGE_CONSUMED, String.valueOf(true));
       // TODO maybe we should remove Headers.MESSAGE_SENT_FROM_CLIENT header here?
     } else {
       log.trace("Marking span with client send");
       span.log(Events.CLIENT_SEND);
-      Tags.SPAN_KIND.set(span, Tags.SPAN_KIND_PRODUCER);
       carrier.put(Headers.MESSAGE_SENT_FROM_CLIENT, "true");
     }
 
     tracer.inject(span.context(), Format.Builtin.TEXT_MAP, carrier);
-
     return carrier.getMessage();
   }
 
@@ -91,7 +99,7 @@ public class OpenTracingChannelInterceptor extends ChannelInterceptorAdapter imp
       return;
     }
 
-    if (activeSpan.getBaggageItem(Events.SERVER_RECEIVE) != null) {
+    if (message.getHeaders().containsKey(Headers.MESSAGE_CONSUMED)) {
       log.trace("Marking span with server send");
       activeSpan.log(Events.SERVER_SEND);
     } else {
@@ -99,10 +107,7 @@ public class OpenTracingChannelInterceptor extends ChannelInterceptorAdapter imp
       activeSpan.log(Events.CLIENT_RECEIVE);
     }
 
-    if (ex != null) {
-      activeSpan.log(Collections.singletonMap(Events.ERROR, ex.getMessage()));
-    }
-
+    handleException(ex, activeSpan);
     log.trace("Closing messaging span " + activeSpan);
     activeSpan.close();
     log.trace(String.format("Messaging span %s successfully closed", activeSpan));
@@ -136,12 +141,23 @@ public class OpenTracingChannelInterceptor extends ChannelInterceptorAdapter imp
     log.trace("Marking span with server send");
     activeSpan.log(Events.SERVER_SEND);
 
+    handleException(ex, activeSpan);
+  }
+
+  /**
+   *  Add exception related tags and logs to a span
+   *
+   * @param ex exception or null
+   * @param span span
+   */
+  protected void handleException(Exception ex, BaseSpan<?> span) {
     if (ex != null) {
-      activeSpan.log(Collections.singletonMap(Events.ERROR, ex.getMessage()));
+      Tags.ERROR.set(span, true);
+      // TODO add exception logs
     }
   }
 
-  private String getChannelName(MessageChannel messageChannel) {
+  protected String getChannelName(MessageChannel messageChannel) {
     String name = null;
     if (ClassUtils.isPresent("org.springframework.integration.context.IntegrationObjectSupport", null)) {
       if (messageChannel instanceof IntegrationObjectSupport) {
@@ -159,10 +175,8 @@ public class OpenTracingChannelInterceptor extends ChannelInterceptorAdapter imp
     return name;
   }
 
-  private String getOperationName(MessageChannel messageChannel) {
+  protected String getOperationName(MessageChannel messageChannel, Operation operation) {
     String channelName = getChannelName(messageChannel);
-
-    return String.format("%s:%s", MESSAGE_COMPONENT, channelName);
+    return String.format("%s:%s", operation, channelName);
   }
-
 }

--- a/opentracing-spring-messaging/src/test/java/io/opentracing/contrib/spring/integration/messaging/OpenTracingChannelInterceptorIT.java
+++ b/opentracing-spring-messaging/src/test/java/io/opentracing/contrib/spring/integration/messaging/OpenTracingChannelInterceptorIT.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.BDDAssertions.then;
 import io.opentracing.Tracer;
 import io.opentracing.mock.MockSpan;
 import io.opentracing.mock.MockTracer;
+import io.opentracing.tag.Tags;
 import io.opentracing.util.ThreadLocalActiveSpanSource;
 import org.junit.After;
 import org.junit.Before;
@@ -213,7 +214,7 @@ public class OpenTracingChannelInterceptorIT implements MessageHandler {
     then(mockTracer.finishedSpans()).hasSize(1);
     MockSpan span = mockTracer.finishedSpans()
         .get(0);
-    then(span.logEntries()).hasSize(3);
+    then(span.logEntries()).hasSize(2);
     then(span.logEntries()
         .get(0)
         .fields()).containsOnlyKeys("event");
@@ -228,13 +229,9 @@ public class OpenTracingChannelInterceptorIT implements MessageHandler {
         .get(1)
         .fields()
         .get("event")).isEqualTo(Events.CLIENT_RECEIVE);
-    then(span.logEntries()
-        .get(2)
-        .fields()).containsOnlyKeys("error");
-    then(span.logEntries()
-        .get(2)
-        .fields()
-        .get("error")).isEqualTo("A terrible exception has occurred");
+    then(span.tags()).hasSize(4);
+    then(span.tags().get(Tags.ERROR.getKey()))
+        .isEqualTo(true);
   }
 
   @Test

--- a/opentracing-spring-messaging/src/test/java/io/opentracing/contrib/spring/integration/messaging/OpenTracingChannelInterceptorTest.java
+++ b/opentracing-spring-messaging/src/test/java/io/opentracing/contrib/spring/integration/messaging/OpenTracingChannelInterceptorTest.java
@@ -14,6 +14,7 @@
 
 package io.opentracing.contrib.spring.integration.messaging;
 
+import static io.opentracing.contrib.spring.integration.messaging.OpenTracingChannelInterceptor.COMPONENT_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyMap;
@@ -28,7 +29,6 @@ import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.propagation.Format;
 import io.opentracing.tag.Tags;
-import java.util.Collections;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -71,6 +71,7 @@ public class OpenTracingChannelInterceptorTest {
     when(mockTracer.buildSpan(anyString())).thenReturn(mockSpanBuilder);
     when(mockSpanBuilder.asChildOf(any(SpanContext.class))).thenReturn(mockSpanBuilder);
     when(mockSpanBuilder.startActive()).thenReturn(mockActiveSpan);
+    when(mockSpanBuilder.withTag(anyString(), anyString())).thenReturn(mockSpanBuilder);
     when(mockActiveSpan.context()).thenReturn(mockSpanContext);
 
     interceptor = new OpenTracingChannelInterceptor(mockTracer);
@@ -81,7 +82,7 @@ public class OpenTracingChannelInterceptorTest {
   @Test
   public void preSendShouldGetNameFromGenericChannel() {
     interceptor.preSend(simpleMessage, mockMessageChannel);
-    verify(mockTracer).buildSpan(String.format("message:%s", mockMessageChannel.toString()));
+    verify(mockTracer).buildSpan(String.format("send:%s", mockMessageChannel.toString()));
   }
 
   @Test
@@ -97,12 +98,12 @@ public class OpenTracingChannelInterceptorTest {
     assertThat(message.getHeaders()).containsKey(Headers.MESSAGE_SENT_FROM_CLIENT);
 
     verify(mockTracer).extract(eq(Format.Builtin.TEXT_MAP), any(MessageTextMap.class));
-    verify(mockTracer).buildSpan(String.format("message:%s", mockMessageChannel.toString()));
+    verify(mockTracer).buildSpan(String.format("send:%s", mockMessageChannel.toString()));
     verify(mockSpanBuilder).asChildOf((SpanContext) null);
     verify(mockSpanBuilder).startActive();
-    verify(mockActiveSpan).setTag(Tags.COMPONENT.getKey(), "spring-messaging");
-    verify(mockActiveSpan).setTag(Tags.MESSAGE_BUS_DESTINATION.getKey(), mockMessageChannel.toString());
-    verify(mockActiveSpan).setTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_PRODUCER);
+    verify(mockSpanBuilder).withTag(Tags.COMPONENT.getKey(), COMPONENT_NAME);
+    verify(mockSpanBuilder).withTag(Tags.MESSAGE_BUS_DESTINATION.getKey(), mockMessageChannel.toString());
+    verify(mockSpanBuilder).withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_PRODUCER);
     verify(mockActiveSpan).log(Events.CLIENT_SEND);
   }
 
@@ -115,12 +116,12 @@ public class OpenTracingChannelInterceptorTest {
     assertThat(message.getPayload()).isEqualTo(originalMessage.getPayload());
 
     verify(mockTracer).extract(eq(Format.Builtin.TEXT_MAP), any(MessageTextMap.class));
-    verify(mockTracer).buildSpan(String.format("message:%s", mockMessageChannel.toString()));
+    verify(mockTracer).buildSpan(String.format("receive:%s", mockMessageChannel.toString()));
     verify(mockSpanBuilder).asChildOf((SpanContext) null);
     verify(mockSpanBuilder).startActive();
-    verify(mockActiveSpan).setTag(Tags.COMPONENT.getKey(), "spring-messaging");
-    verify(mockActiveSpan).setTag(Tags.MESSAGE_BUS_DESTINATION.getKey(), mockMessageChannel.toString());
-    verify(mockActiveSpan).setTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CONSUMER);
+    verify(mockSpanBuilder).withTag(Tags.COMPONENT.getKey(), COMPONENT_NAME);
+    verify(mockSpanBuilder).withTag(Tags.MESSAGE_BUS_DESTINATION.getKey(), mockMessageChannel.toString());
+    verify(mockSpanBuilder).withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CONSUMER);
     verify(mockActiveSpan).log(Events.SERVER_RECEIVE);
   }
 
@@ -143,10 +144,11 @@ public class OpenTracingChannelInterceptorTest {
 
   @Test
   public void afterSendCompletionShouldFinishSpanForServerSendMessage() {
+    Message<?> message = MessageBuilder.fromMessage(simpleMessage)
+        .setHeader(Headers.MESSAGE_CONSUMED, true)
+        .build();
     when(mockTracer.activeSpan()).thenReturn(mockActiveSpan);
-    when(mockActiveSpan.getBaggageItem(Events.SERVER_RECEIVE)).thenReturn(Events.SERVER_RECEIVE);
-
-    interceptor.afterSendCompletion(null, null, true, null);
+    interceptor.afterSendCompletion(message, null, true, null);
 
     verify(mockTracer).activeSpan();
     verify(mockActiveSpan).log(Events.SERVER_SEND);
@@ -158,7 +160,7 @@ public class OpenTracingChannelInterceptorTest {
   public void afterSendCompletionShouldFinishSpanForClientSendMessage() {
     when(mockTracer.activeSpan()).thenReturn(mockActiveSpan);
 
-    interceptor.afterSendCompletion(null, null, true, null);
+    interceptor.afterSendCompletion(simpleMessage, null, true, null);
 
     verify(mockTracer).activeSpan();
     verify(mockActiveSpan).log(Events.CLIENT_RECEIVE);
@@ -169,12 +171,11 @@ public class OpenTracingChannelInterceptorTest {
   @Test
   public void afterSendCompletionShouldFinishSpanForException() {
     when(mockTracer.activeSpan()).thenReturn(mockActiveSpan);
-
-    interceptor.afterSendCompletion(null, null, true, new Exception("test"));
+    interceptor.afterSendCompletion(simpleMessage, null, true, new Exception("test"));
 
     verify(mockTracer).activeSpan();
     verify(mockActiveSpan).log(Events.CLIENT_RECEIVE);
-    verify(mockActiveSpan).log(Collections.singletonMap(Events.ERROR, "test"));
+    verify(mockActiveSpan).setTag(Tags.ERROR.getKey(), true);
     verify(mockActiveSpan).close();
   }
 
@@ -208,7 +209,7 @@ public class OpenTracingChannelInterceptorTest {
   public void afterMessageHandledShouldLogEvent() {
     when(mockTracer.activeSpan()).thenReturn(mockActiveSpan);
 
-    interceptor.afterMessageHandled(null, null, null, null);
+    interceptor.afterMessageHandled(simpleMessage, null, null, null);
 
     verify(mockTracer).activeSpan();
     verify(mockActiveSpan).log(Events.SERVER_SEND);
@@ -223,7 +224,7 @@ public class OpenTracingChannelInterceptorTest {
 
     verify(mockTracer).activeSpan();
     verify(mockActiveSpan).log(Events.SERVER_SEND);
-    verify(mockActiveSpan).log(Collections.singletonMap(Events.ERROR, "test"));
+    verify(mockActiveSpan).setTag(Tags.ERROR.getKey(), true);
   }
 
 }


### PR DESCRIPTION
Use OT tags at span creation time to align with the spec. Minor code simplification.